### PR TITLE
[WIP] ログイン、新規登録ビューのブラッシュアップ

### DIFF
--- a/app/assets/stylesheets/devise/_devise.scss
+++ b/app/assets/stylesheets/devise/_devise.scss
@@ -1,9 +1,47 @@
-.main--devise{
+.devise{
+  color: $black;
+  padding-top: 200px;
   width: 100%;
-  margin-top: 20px;
-  
-  & .devise{
-    @include noted;
-    padding-top: 100px;
+  background-color: $main-color;
+  &--registrations{
+    padding-top: 130px;
+  }
+  &__body{
+    display: flex;
+    flex-flow: column wrap;
+    @include noted(430px, 500px);
+    & h2{
+      text-align: center;
+      font-size: 25px;
+      border-bottom: dotted 2px $light;
+      padding-top: 20px;
+    }
+    & .new_user{
+      font-size: 18px;
+      text-align: center;
+      border-bottom: dotted 2px $light;
+    }
+    & .if_sessions{
+      text-align: right;
+      margin: 10px;
+      & a{
+        @include reset_a-tag(black);
+      }
+    }
+    &__inputForm{
+      & label{
+        line-height: 40px;
+      }
+      @include devise_form();
+    }
+    &__button{
+      & input{
+        @include reset_form();
+        border: 1px $black solid;
+        padding: 3px 10px;
+        color: $black;
+      }
+      margin: 10px;
+    }
   }
 }

--- a/app/assets/stylesheets/mixin/_fav-setting.scss
+++ b/app/assets/stylesheets/mixin/_fav-setting.scss
@@ -14,9 +14,9 @@
 
 // ノート風のスタイル
 @mixin noted($noted-height: 500px, $noted-width: 500px){
-  border: double 5px black;
+  border: double 5px $black;
   margin: 0 auto;
-  box-shadow: 0 0 10px gray;
+  box-shadow: 0 0 5px $black;
   background-color: white;
   max-width: $noted-width;
   min-height: $noted-height;
@@ -29,4 +29,18 @@
   background-color: $color;
   box-shadow: 1px 1px 2px darken($color, $darken);
   margin: $margin-height $margin-width;
+}
+
+@mixin devise_form {
+  margin: 30px 0px;
+  & input{
+    @include reset_form();
+    border: 1px solid $black;
+    width: 300px;
+    height: 40px;
+    padding-left: 10px;
+    &:focus{
+      border: solid 1px $blue;
+    }
+  }
 }

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,29 +1,27 @@
-.main.main--devise
-  .devise.devise--signup
-    %h2 Sign up
-    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+.devise.devise--registrations
+  .devise__body
+    %h2 ユーザー登録
+    = form_for(resource, as: resource_name, class: "devise__form", url: registration_path(resource_name)) do |f|
       = render "devise/shared/error_messages", resource: resource
-      .field
-        = f.label :nickname
+      .field.devise__body__inputForm
+        = f.label :nickname, "ニックネーム"
         %br/
-        = f.text_field :nickname, autofocus: true, autocomplete: "nickname"
-      .field
-        = f.label :email
+        = f.text_field :nickname, autofocus: true
+      .field.devise__body__inputForm
+        = f.label :email, "メールアドレス"
         %br/
-        = f.email_field :email, autofocus: true, autocomplete: "email"
-      .field
-        = f.label :password
+        = f.email_field :email, autocomplete: "email"
+      .field.devise__body__inputForm
+        = f.label :password, "パスワード"
         - if @minimum_password_length
           %em
-            (#{@minimum_password_length} characters minimum)
+            (#{@minimum_password_length} 文字以上)
         %br/
         = f.password_field :password, autocomplete: "new-password"
-      .field
-        = f.label :password_confirmation
+      .field.devise__body__inputForm
+        = f.label :password_confirmation, "パスワード確認"
         %br/
         = f.password_field :password_confirmation, autocomplete: "new-password"
-      .field
-        = recaptcha_tags callback: 'recaptchaCallbackFunction'
-      .actions
-        = f.submit "Sign up", id:"deviseSubmit",disabled: "disabled"
+      .actions.devise__body__button
+        = f.submit "登録する"
     = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,19 +1,19 @@
-.main.main--devise
-  .devise.devise--sessions
-    %h2 Log in
-    = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-      .field
-        = f.label :email
+.devise
+  .devise__body
+    %h2 ログイン
+    = form_for(resource, as: resource_name, class: "devise__form", url: session_path(resource_name)) do |f|
+      .field.devise__body__inputForm
+        = f.label :email, "メールアドレス"
         %br/
         = f.email_field :email, autofocus: true, autocomplete: "email"
-      .field
-        = f.label :password
+      .field.devise__body__inputForm
+        = f.label :password, "パスワード"
         %br/
         = f.password_field :password, autocomplete: "current-password"
       - if devise_mapping.rememberable?
         .field
           = f.check_box :remember_me
-          = f.label :remember_me
-      .actions
-        = f.submit "Log in"
+          = f.label :remember_me, "ログインを記録"
+      .actions.devise__body__button
+        = f.submit "ログインする"
     = render "devise/shared/links"

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,19 +1,20 @@
-- if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
-  %br/
-- if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
-  %br/
-- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
-  %br/
-- if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
-  %br/
-- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
-  %br/
-- if devise_mapping.omniauthable?
-  - resource_class.omniauth_providers.each do |provider|
-    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+.if_sessions
+  - if controller_name != 'sessions'
+    = link_to "登録済みの方はこちら", new_session_path(resource_name)
     %br/
+  - if devise_mapping.registerable? && controller_name != 'registrations'
+    = link_to "ユーザー登録はこちら", new_registration_path(resource_name)
+    %br/
+-#   - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+-#     = link_to "Forgot your password?", new_password_path(resource_name)
+-#     %br/
+  - if devise_mapping.confirmable? && controller_name != 'confirmations'
+    = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+    %br/
+  - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+    = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+    %br/
+  - if devise_mapping.omniauthable?
+    - resource_class.omniauth_providers.each do |provider|
+      = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+      %br/


### PR DESCRIPTION
# What
ログイン画面、新規登録画面のビューを改善する
# Why
現在deviseのデフォルトのビューを利用しており、ごちゃごちゃして使いにくいUIになっているため
## ログイン画面
[![Image from Gyazo](https://i.gyazo.com/f2a2280621a5ffd6ad03bf4ed6b70339.png)](https://gyazo.com/f2a2280621a5ffd6ad03bf4ed6b70339)
## 新規登録画面
[![Image from Gyazo](https://i.gyazo.com/cb6838cdb6cc8f4456d7e7ce0a32d44c.png)](https://gyazo.com/cb6838cdb6cc8f4456d7e7ce0a32d44c)