### PR TITLE
テスト結果一覧表示ビューの微調整

### DIFF
--- a/app/assets/stylesheets/testresult/_index.scss
+++ b/app/assets/stylesheets/testresult/_index.scss
@@ -35,14 +35,16 @@
 }
 
 .sideBar{
-  &__top{
-    height: 30px;
-  }
   &--indexTestresult{
     width: 20%;
     height: $main-height;
     border-left: 1px solid $black;
     background-color: $white;
+    &__top{
+      @include text_center(30px, center);
+      @include font_data($black, 18px, bold);
+      border-bottom: 1px solid $black;
+    }
     .testresults{
       overflow: scroll;
       height: calc(#{$main-height} - 30px);

--- a/app/views/testresults/index.html.haml
+++ b/app/views/testresults/index.html.haml
@@ -14,7 +14,7 @@
       = button_tag "Radar"
   .charts.charts--empty
 .sideBar.sideBar--indexTestresult
-  .sideBar__top
+  .sideBar--indexTestresult__top
     %p 受験したテスト一覧
   .testresults
     - @testresults.each.with_index do |testresult,i|


### PR DESCRIPTION
# What
テスト結果一覧表示のサイドバーのクラス名を変更
# Why
他のページのクラス名と同一になり表示の崩れが発生していたため