### PR TITLE
テスト受験画面のブラッシュアップ

### DIFF
--- a/app/assets/stylesheets/test/_show.scss
+++ b/app/assets/stylesheets/test/_show.scss
@@ -1,23 +1,31 @@
 .main--showTest{
+  width: 100%;
   & .testcards{
     width: 900px;
-    margin: 0 auto;
+    padding-bottom: 90px;
+    margin: 20px auto;
+    border: 1px solid $black;
     & .testcard{
-      @include card_style(90px,850px);
+      width: 90%;
+      margin: 20px auto;
+      padding-bottom: 20px;
+      border-bottom: 1px solid $black;
       &__top{
-        @include font_data(black,22px);
+        @include font_data($black,20px,bold);
       }
       &__word{
-        @include font_data(black,20px,bold);
+        @include font_data($black,20px);
         width: 23%;
       }
-      &__submit{
-        @include reset_form;
-        width:100px;
-        height: 100px;
-        border: solid 2px gray;
-        float: right;
-      }
+    }
+    &__submit{
+      @include reset_form;
+      color: $black;
+      width: 200px;
+      height: 50px;
+      border: solid 2px $black;
+      margin: 20px;
+      float: right;
     }
   }
 }

--- a/app/assets/stylesheets/testresult/_show.scss
+++ b/app/assets/stylesheets/testresult/_show.scss
@@ -8,8 +8,6 @@
 
       border: 1px solid $black;
       padding: 10px 20px;
-      & canvas{
-      }
     }
   }
   & .testresult-detail{

--- a/app/views/tests/show.html.haml
+++ b/app/views/tests/show.html.haml
@@ -4,12 +4,11 @@
       - @wordbook.test.questions.each.with_index do |question,i|
         .testcard
           .testcard__top
-            = "[#{i+1}] #{question.word.front}"
+            = question.word.front
           .flexbox
             - question.testwords.order("RAND()").each.with_index do |testword,j|
               .testcard__word{"data-id": i*10 + j}
-                = f.radio_button :id, testword.id, name:"testresult[testword_id][q#{testword.question.id}]"
-                = f.label :id, testword.word
-      = f.submit value:"解答", class:"testcard__submit"
-.sideBar.sideBar--showTest
-  テストエリアですよ
+                = f.label :id, for: "testresult_id_#{testword.id}" do
+                  = f.radio_button :id, testword.id, name:"testresult[testword_id][q#{testword.question.id}]",required: "on"
+                  = testword.word
+      = f.submit value:"解答", class:"testcards__submit"


### PR DESCRIPTION
# What
テスト受験画面のブラッシュアップを行う
# Why
現在のcardstyleの画面では必要な情報がシンプルに表示されていないその改善
また入力途中の誤送信がありうるなどUI/UXの面で劣っているため
## 結果
[![Image from Gyazo](https://i.gyazo.com/b60efdef4c385036442fff4838cf8f7b.png)](https://gyazo.com/b60efdef4c385036442fff4838cf8f7b)