### PR TITLE
単語カード表示機能のブラッシュアップ

### DIFF
--- a/app/assets/javascripts/word.js
+++ b/app/assets/javascripts/word.js
@@ -22,13 +22,13 @@ $(function(){
   function appendHTML(word, onoff){
     var put = onoff == "front" ? word.front : word.reverse;
     var HTML = `
-    <div class = "wordcard wordcard--${onoff}">
-      <div class = "wordcard__word">
+    <div class = "main--showWordBook__wordcard main--showWordBook__wordcard--${onoff}">
+      <div class = "main--showWordBook__wordcard__word">
         ${put}
       </div>
     </div>
     `
-    $(".wordcards").html(HTML);
+    $(".main--showWordBook__wrapper").html(HTML);
   }
 
   // 左矢印が押された際に前の単語を表示する
@@ -51,10 +51,10 @@ $(function(){
   showWordBook ? wordcard() : null ;
 
   // 裏表を入れ替える
-  $(document).on("click",".wordcard--front",function(){
+  $(document).on("click",".main--showWordBook__wordcard--front",function(){
     appendHTML(cards[count],"reverse");
   })
-  $(document).on("click",".wordcard--reverse",function(){
+  $(document).on("click",".main--showWordBook__wordcard--reverse",function(){
     appendHTML(cards[count],"front");
   })
 });

--- a/app/assets/stylesheets/mixin/_fav-setting.scss
+++ b/app/assets/stylesheets/mixin/_fav-setting.scss
@@ -88,3 +88,12 @@
     }
   }
 }
+
+// 親要素にrelativeが指定されていた場合に中央寄せする
+@mixin absoluteCenter($top: 50%, $left: 50%) {
+  position: absolute;
+  top: $top;
+  left: $left;
+  transform: translate(0, -50%);
+  transform: translate(0, -50%);
+}

--- a/app/assets/stylesheets/wordbook/_show.scss
+++ b/app/assets/stylesheets/wordbook/_show.scss
@@ -29,4 +29,13 @@
       color: black;
     }
   }
+  &__footer{
+    position: fixed;
+    bottom: 10px;
+    right: 30px;
+    font-size: 20px;
+    & a{
+      @include reset_a-tag($black);
+    }
+  }
 }

--- a/app/assets/stylesheets/wordbook/_show.scss
+++ b/app/assets/stylesheets/wordbook/_show.scss
@@ -1,20 +1,24 @@
-
 .main--showWordBook{
   width: 100%;
   display: flex;
   flex-flow: row nowrap;
-  & .wordcards{
+  &__wrapper{
     width: 100%;
-    & .wordcard{
-      @include card_style(600px,80%);
-      @include font_data(black,100px,bold);
-      margin: 30px auto;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      &__word{
-        overflow-wrap: break-word;
-      }
+    position: relative;
+  }
+  &__wordcard{
+    @include absoluteCenter(45%, 10%);
+    @include card_style(80%,80%);
+    @include font_data(black,100px,bold);
+    margin: 30px auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    &__word{
+      width: 95%;
+      margin: 0 auto;
+      text-align: center;
+      overflow-wrap: break-word;
     }
   }
   & .button__arrow{

--- a/app/views/wordbooks/show.html.haml
+++ b/app/views/wordbooks/show.html.haml
@@ -3,9 +3,9 @@
   .main.main--showWordBook{"data-id": id}
     = button_tag class:"button__arrow button__arrow--left" do
       = icon('fas fa-5x', 'chevron-left')
-    .wordcards
-      .wordcard.wordcard--front
-        .wordcard__word
+    .main--showWordBook__wrapper
+      .main--showWordBook__wordcard.main--showWordBook__wordcard--front
+        .main--showWordBook__wordcard__word
           = @wordbook.words.first.front
     = button_tag class:"button__arrow button__arrow--right" do
       = icon("fas fa-5x","chevron-right")

--- a/app/views/wordbooks/show.html.haml
+++ b/app/views/wordbooks/show.html.haml
@@ -9,3 +9,8 @@
           = @wordbook.words.first.front
     = button_tag class:"button__arrow button__arrow--right" do
       = icon("fas fa-5x","chevron-right")
+    %footer.main--showWordBook__footer
+      = link_to wordbook_words_path(@wordbook.id) do
+        - 2.times do
+          = icon("fas", "arrow-right")
+        単語カード一覧表示


### PR DESCRIPTION
# What
1. リファクタリング
2. 単語カード一覧表示ページへのリンクを付け加える
3. 解像度に合わせた表示領域を設定する
4. 文字が中央に集まるように設定する
# Why
1. 現在複数箇所にwordcardを設定しており、それらの設定が適切に分離されていないため
2.  現在の最後の単語帳を見るまで一覧表示ページにアクセスできない仕様はUXに劣るため
3. 解像度を変更した際に上下が見切れることを対応するため
4. 文字数が多くなった際に文字が左側に偏って見えるため
## 結果
[![Image from Gyazo](https://i.gyazo.com/57fa224357453a0380378ce25db2491b.gif)](https://gyazo.com/57fa224357453a0380378ce25db2491b)