### PR TITLE
お気に入り機能の堅牢性を高める

### DIFF
--- a/app/controllers/api/wordbooks_controller.rb
+++ b/app/controllers/api/wordbooks_controller.rb
@@ -1,9 +1,14 @@
 class Api::WordbooksController < ApplicationController
+  before_action :set_favorite
   def update
     @fav = Favorite.create(user_id: current_user.id,wordbook_id: params[:id])
   end
   def destroy
-    @fav = Favorite.where(wordbook_id: params[:id]).find_by(user_id: current_user.id)
     @fav.destroy
+  end
+
+  private
+  def set_favorite
+    @fav = Favorite.where(wordbook_id: params[:id]).find_by(user_id: current_user.id)
   end
 end

--- a/app/controllers/api/wordbooks_controller.rb
+++ b/app/controllers/api/wordbooks_controller.rb
@@ -1,8 +1,11 @@
 class Api::WordbooksController < ApplicationController
   before_action :set_favorite
   def update
-    @fav = Favorite.create(user_id: current_user.id,wordbook_id: params[:id])
+    unless @fav.present?
+      Favorite.create(user_id: current_user.id, wordbook_id: params[:id])
+    end
   end
+
   def destroy
     @fav.destroy
   end

--- a/app/controllers/wordbooks_controller.rb
+++ b/app/controllers/wordbooks_controller.rb
@@ -27,7 +27,7 @@ class WordbooksController < ApplicationController
   end
   def destroy
     @wordbook.destroy
-    redirect_to root_path
+    redirect_to user_path(current_user.id)
   end
 
   def show


### PR DESCRIPTION
# What
複数回お気に入りを作成できないように設定する
# Why
現在reloadを挟まずにお気に入りを連打すると複数個のお気に入りが作成されるため、その対策を行う。