### PR TITLE
管理者機能の実装

### DIFF
--- a/app/assets/stylesheets/admin/index.scss
+++ b/app/assets/stylesheets/admin/index.scss
@@ -1,0 +1,11 @@
+.users{
+  margin: 100px;
+  & th{
+    line-height: 40px;
+    padding: 5px;
+  }
+  & td{
+    line-height: 40px;
+    padding: 5px;
+  }
+} 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,4 @@
 @import "testresult/show";
 @import "testresult/index";
 @import "devise/devise";
+@import "admin/index";

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,0 +1,2 @@
+class AdminsController < ApplicationController
+end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,5 +1,9 @@
 class AdminsController < ApplicationController
   before_action :admin?
+
+  def index
+    @users = User.includes(:wordbooks)
+  end
   private
   def admin?
     redirect_to root_path unless current_user&.admin

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,2 +1,7 @@
 class AdminsController < ApplicationController
+  before_action :admin?
+  private
+  def admin?
+    redirect_to root_path unless current_user&.admin
+  end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -4,6 +4,12 @@ class AdminsController < ApplicationController
   def index
     @users = User.includes(:wordbooks)
   end
+
+  def destroy
+    Wordbook.find(params[:id]).destroy
+    redirect_to admins_path
+  end
+
   private
   def admin?
     redirect_to root_path unless current_user&.admin

--- a/app/views/admins/index.html.haml
+++ b/app/views/admins/index.html.haml
@@ -1,0 +1,19 @@
+.flexbox
+  %table.users(border = "1")
+    %tbody
+      %tr
+        %th
+          ID
+        %th
+          ニックネーム
+        %th
+          記事
+      - @users.each do |user|
+        %tr
+          %td
+            = user.id
+          %td
+            = user.nickname
+          %td
+            - user.wordbooks.each do |wordbook|
+              = link_to wordbook.title, admin_path(wordbook.id), method: :delete

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,6 +29,10 @@
           = link_to destroy_user_session_path, method: :delete, class: "header__icons__icon" do
             = icon('fas fa-3x', 'sign-out-alt')
             %p.header__icons__icon__explain ログアウト
+          - if current_user&.admin
+            = link_to admins_path, class: "header__icons__icon" do
+              = icon("fas fa-3x", "eye")
+              %p.header__icons__icon__explain 管理者画面
         - else
           = link_to new_user_session_path, class: "header__icons__icon" do
             = icon('fas fa-3x', 'sign-in-alt')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,5 @@ Rails.application.routes.draw do
       resources :testresults, only: [:index,:new], defaults: { format: 'json' }
     end
   end
+  resources :admins, only:[:index, :destroy]
 end

--- a/db/migrate/20191013163943_add_admin_to_user.rb
+++ b/db/migrate/20191013163943_add_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_18_122704) do
+ActiveRecord::Schema.define(version: 2019_10_13_163943) do
 
   create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 2019_08_18_122704) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# What
管理者機能を実装する。
# Why
アプリケーションを公開するにあたって削除が必要な記事等が投稿される可能性がある。
そのたびにSQLを用いてDBに変更を加えるのは非効率であり、管理者画面の実装が必要である。
## headerのアイコン
[![Image from Gyazo](https://i.gyazo.com/fef4670234bb9d51413ac3cb02180867.png)](https://gyazo.com/fef4670234bb9d51413ac3cb02180867)

## 管理者画面
[![Image from Gyazo](https://i.gyazo.com/0e337db597da3feaade383f8195ac6bc.png)](https://gyazo.com/0e337db597da3feaade383f8195ac6bc)