### PR TITLE
登録できる文字数を変更する

### DIFF
--- a/app/assets/stylesheets/test/_new.scss
+++ b/app/assets/stylesheets/test/_new.scss
@@ -34,6 +34,7 @@
           box-shadow: 0px 0px 2px $black;
         }
         &--correct{
+          width: 500px;
           border: none;
           border-bottom: 3px double $black;
           &:focus{

--- a/app/assets/stylesheets/word/_createWord.scss
+++ b/app/assets/stylesheets/word/_createWord.scss
@@ -1,4 +1,10 @@
 .createWord{
-  @include input_form(500px);
+  @include input_form(380px);
   margin-top: $create-wordcard-height;
+  &__form{
+    &__input{
+      height: 80px;
+      line-height: 40px;
+    }
+  }
 }

--- a/app/models/testword.rb
+++ b/app/models/testword.rb
@@ -3,5 +3,5 @@ class Testword < ApplicationRecord
   has_many :selections, dependent: :destroy
   has_many :testresults, through: :selections, dependent: :destroy
 
-  validates :word, presence: true, length: { maximum: 20 }
+  validates :word, presence: true, length: { maximum: 30 }
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -3,6 +3,6 @@ class Word < ApplicationRecord
   has_one :question, dependent: :destroy
   has_many :images, dependent: :destroy
 
-  validates :front, presence: true, length: { maximum: 20 }
-  validates :reverse, presence: true, length: { maximum: 20 }
+  validates :front, presence: true, length: { maximum: 30 }
+  validates :reverse, presence: true, length: { maximum: 30 }
 end

--- a/app/views/tests/new.html.haml
+++ b/app/views/tests/new.html.haml
@@ -3,7 +3,7 @@
   = form_for [@wordbook,@test] do |f|
     .newTests
       %p.newTests__example
-        裏の言葉は入力済み(編集可能)です、誤答を３つ入力してください(20文字以内)
+        裏の言葉は入力済み(編集可能)です、誤答を３つ入力してください(30文字以内)
       - @wordbook.words.each.with_index do |word,i|
         .newTests__test
           .newTests__test__top
@@ -11,6 +11,6 @@
           = f.text_field :word, class:"newTests__test__input newTests__test__input--correct", placeholder:"正解を入力", name: "words[t#{i}][]", autocomplete: "off", maxlength: "20", required: "on", value: word.reverse
           %br
           - 3.times do
-            = f.text_field :word, class:"newTests__test__input", placeholder:"誤答を入力", name: "words[t#{i}][]", autocomplete: "off", maxlength: "20", required: "on", autofocus: "on"
+            = f.text_field :word, class:"newTests__test__input", placeholder:"誤答を入力", name: "words[t#{i}][]", autocomplete: "off", maxlength: "30", required: "on", autofocus: "on"
       .newTests__submit
         = f.submit "テストを作成"

--- a/app/views/words/_createWord.html.haml
+++ b/app/views/words/_createWord.html.haml
@@ -3,11 +3,11 @@
     = f.label :front, "表の言葉"
     %span.require
       必須
-    = f.text_field :front, class: "createWord__form__input", value: word.front, required: "on", autocomplete: "off", placeholder: "20文字以内",  maxlength: "20" , autofocus: "on"
+    = f.text_field :front, class: "createWord__form__input", value: word.front, required: "on", autocomplete: "off", placeholder: "30文字以内",  maxlength: "30" , autofocus: "on"
   .createWord__form
     = f.label :reverse, "裏の言葉"
     %span.require
       必須
-    = f.text_field :reverse, class: "createWord__form__input", value: word.reverse, required: "on", autocomplete: "off", placeholder: "20文字以内",  maxlength: "20"
+    = f.text_field :reverse, class: "createWord__form__input", value: word.reverse, required: "on", autocomplete: "off", placeholder: "30文字以内",  maxlength: "30"
   .createWord__submit
     = f.submit

--- a/app/views/words/_createWord.html.haml
+++ b/app/views/words/_createWord.html.haml
@@ -3,11 +3,11 @@
     = f.label :front, "表の言葉"
     %span.require
       必須
-    = f.text_field :front, class: "createWord__form__input", value: word.front, required: "on", autocomplete: "off", placeholder: "30文字以内",  maxlength: "30" , autofocus: "on"
+    = f.text_area :front, class: "createWord__form__input", value: word.front, required: "on", autocomplete: "off", placeholder: "30文字以内",  maxlength: "30" , autofocus: "on"
   .createWord__form
     = f.label :reverse, "裏の言葉"
     %span.require
       必須
-    = f.text_field :reverse, class: "createWord__form__input", value: word.reverse, required: "on", autocomplete: "off", placeholder: "30文字以内",  maxlength: "30"
+    = f.text_area :reverse, class: "createWord__form__input", value: word.reverse, required: "on", autocomplete: "off", placeholder: "30文字以内",  maxlength: "30"
   .createWord__submit
     = f.submit


### PR DESCRIPTION
# What
単語カードに登録できる文字数を変更する
# Why
現在の20文字制限では十分な情報を伝えることはできないため