### PR TITLE
単語カード一覧表示ページをレスポンシブ化

### DIFF
--- a/app/assets/stylesheets/word/_wordTop.scss
+++ b/app/assets/stylesheets/word/_wordTop.scss
@@ -1,4 +1,7 @@
 .wordTop{
+  @include mq(mobile){
+    display: none;
+  }
   height:  $create-wordcard-height;
   border-bottom: 1px solid $black;
   @include font_data($black, 20px, bold);

--- a/app/assets/stylesheets/word/_wordcard.scss
+++ b/app/assets/stylesheets/word/_wordcard.scss
@@ -5,12 +5,16 @@
   align-content: space-around;
   &--index{
     margin: 0 auto;
-    max-width: 1000px;
-    min-width: 850px;
+    width: 1000px;
     align-content: flex-start;
     height: calc(#{$main-height} - #{$create-wordcard-height});
     overflow: scroll;
     @include hiddenScrollBar;
+    @include mq(mobile){
+      padding-top: 60px;
+      width: 370px;
+      height: $main-height;
+    }
   }
   & .wordcard{
     @include card_style;

--- a/app/assets/stylesheets/word/index.scss
+++ b/app/assets/stylesheets/word/index.scss
@@ -1,3 +1,6 @@
+.main--indexWord{
+}
+
 .sideBar--indexWord{
   background-color: $white;
   border-left: 1px solid $black;
@@ -17,6 +20,29 @@
       & i{
         position: absolute;
         left: 20px;
+      }
+    }
+  }
+  @include mq(mobile){
+    width: 100%;
+    height: 30px;
+    border: none;
+    float: none;
+    border-bottom: 1px solid $black;
+    &__link{
+      margin: 0;
+      width: 50px;
+      height: 50px;
+      & a{
+        & p{
+          bottom: 30px;
+          left: 0px;
+        }
+        & i{
+          font-size: 40px;
+          bottom:30px;
+          left: 40px;
+        }
       }
     }
   }


### PR DESCRIPTION
# What
単語カード一覧表示ページをレスポンシブ化する
# Why
スマートフォンに対応することでユーザーの枠を広げるため

## スマホ画面
[![Image from Gyazo](https://i.gyazo.com/0549689e484985af3c57b2298e023e79.png)](https://gyazo.com/0549689e484985af3c57b2298e023e79)